### PR TITLE
add cdnjs example

### DIFF
--- a/src/docs/installation.md
+++ b/src/docs/installation.md
@@ -12,6 +12,10 @@ npm install art-template --save
 
 ## 浏览器
 
+```html
+<script src="https://cdnjs.cloudflare.com/ajax/libs/art-template/4.9.0/template-web.js"></script>
+```
+
 下载：[lib/template-web.js](https://raw.githubusercontent.com/aui/art-template/master/lib/template-web.js)（gzip: 6kb）
 
 **兼容**


### PR DESCRIPTION
依照 https://github.com/cdnjs/cdnjs/pull/11285/commits/2db2f8d8d7150353b0e21694d98d968ec8432979 此篇，網址會是 https://cdnjs.cloudflare.com/ajax/libs/art-template/4.9.0/template-web.js。

但因為 cdnjs 還查不到。所以先不能 merge。